### PR TITLE
Tests for 'relatedLot' patching with 'bot' auth

### DIFF
--- a/openregistry/assets/basic/tests/asset_blanks.py
+++ b/openregistry/assets/basic/tests/asset_blanks.py
@@ -510,6 +510,21 @@ def asset_bot_patch(self):
 
     self.app.authorization = ('Basic', ('bot', ''))
 
+    lot_id = uuid4().hex
+
+    response = self.app.patch_json('/assets/{}'.format(
+        asset['id']), {'data': {'relatedLot': lot_id}})
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    self.assertEqual(response.json['data']['relatedLot'], lot_id)
+
+    response = self.app.patch_json('/assets/{}'.format(
+        asset['id']), {'data': {'relatedLot': None}})
+    self.assertEqual(response.status, '200 OK')
+    self.assertEqual(response.content_type, 'application/json')
+    related_lot = response.json['data'].get('relatedLot', '')
+    self.assertEqual(related_lot, '')
+
     response = self.app.get('/assets/{}'.format(asset['id']))
     self.assertEqual(response.status, '200 OK')
     self.assertEqual(response.content_type, 'application/json')


### PR DESCRIPTION
https://github.com/openprocurement/openregistry.assets.core/pull/7